### PR TITLE
Fix header to be older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,16 +6,12 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>Chat Assistant</title>
     <link rel="stylesheet" href="style.css?v=14">
 </head>
 <body>
     <div class="container">
         <header>
-            <div>
-                <h1>Course Materials Assistant</h1>
-                <p class="subtitle">Ask questions about courses, instructors, and content</p>
-            </div>
             <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
                 <span class="theme-icon sun">☀️</span>
                 <span class="theme-icon moon">🌙</span>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -75,27 +75,11 @@ body {
 header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     padding: 1rem 2rem;
-    border-bottom: 1px solid var(--border-color);
     background: var(--surface);
 }
 
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {
@@ -977,13 +961,7 @@ details[open] .suggested-header::before {
     
     header {
         padding: 1rem;
-        flex-direction: column;
-        gap: 1rem;
-        text-align: center;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
+        justify-content: center;
     }
     
     .theme-toggle {


### PR DESCRIPTION
Reverts the header to an older version by removing the Course Materials Assistant title, subtitle, and horizontal border while keeping the theme toggle functionality.

Changes:
- Removed "Course Materials Assistant" title
- Removed subtitle about courses/instructors/content
- Removed horizontal row below header
- Preserved theme toggle button and functionality
- Updated page title to "Chat Assistant"
- Cleaned up unused CSS styles

Fixes #2

Generated with [Claude Code](https://claude.ai/code)